### PR TITLE
fix #4: remove the script's type attribute

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
 <body>
-<script type="text/javascript">
+<script>
 function makeCall(endpointName) {
   console.log(endpointName);
   var request = new XMLHttpRequest()


### PR DESCRIPTION
It was pointed out by https://validator.w3.org/ that it is not needed as it is well established as the defacto default.