### PR TITLE
fix #6 and fix #8: structure endpoints more consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A web based app for controlling a Yamaha amplifier using the Extended Control AP
 sudo apt update
 sudo apt install golang
 go get -v github.com/gorilla/mux
+go get -v gopkg.in/go-playground/validator.v9
 ```
 
 ## Format and Test
@@ -20,3 +21,19 @@ make
 make run
 ```
 Open http://localhost:8080/
+
+You may call it programmatically, for example:
+```bash
+curl -i http://localhost:8080/ping
+```
+Which ought to return the JSON `true`.
+
+Or more usefully:
+```bash
+curl -i -X POST --data '{"mute": "mute"}' --header 'Content-Type: application/json' http://localhost:8080/\$setMute
+```
+Or:
+```bash
+curl -i -X POST --data '{"volume": "down"}' --header 'Content-Type: application/json' http://localhost:8080/\$setVolume
+```
+

--- a/static/index.html
+++ b/static/index.html
@@ -7,10 +7,11 @@
 </head>
 <body>
 <script>
-function makeCall(endpointName) {
-  console.log(endpointName);
+function makeCall(httpMethod, endpointName, jsonObj) {
+  const jsonText = JSON.stringify(jsonObj);
+  console.log(httpMethod + ' ' + endpointName + ' of ' + jsonText);
   var request = new XMLHttpRequest()
-  request.open('GET', endpointName, true)
+  request.open('POST', endpointName, true)
   request.onreadystatechange = function () {
     if (request.readyState !== 4) {
       return;
@@ -28,19 +29,31 @@ function makeCall(endpointName) {
         '\n' + request.responseText);
     }
   }
-  request.send();
+  request.send(jsonText);
 }
+
+function setMute(mute) {
+  makeCall('POST', '/$setMute', {"mute": mute});
+}
+
+function setVolume(volume) {
+  makeCall('POST', '/$setVolume', {"volume": volume});
+}
+
 function mute() {
-  makeCall('/mute')
+  setMute('mute');
 }
+
 function unmute() {
-  makeCall('/unmute')
+  setMute('unmute');
 }
+
 function volumeUp() {
-  makeCall('/volumeUp')
+  setVolume('up');
 }
+
 function volumeDown() {
-  makeCall('/volumeDown')
+  setVolume('down');
 }
 </script>
 <h1>Hi-Fi Control</h1>
@@ -51,3 +64,4 @@ function volumeDown() {
 <button onclick="volumeDown()">Volume Down</button>
 </body>
 </html>
+


### PR DESCRIPTION
Use '$' prefixed POST calls for actions.
Pass parameters as validated JSON object fields.